### PR TITLE
feat: enable HTTP-based FastMCP server for Realman robot

### DIFF
--- a/realman/RMC-LA/README.md
+++ b/realman/RMC-LA/README.md
@@ -1,1 +1,116 @@
-# Add instructions for robot deployment
+# 🤖 Realman Robot Skill Server
+
+This project provides skill services for a Realman robot, including object grasping with a wrist-mounted camera and target navigation. It integrates:
+
+- 🦾 Realman Arm SDK
+- 🦿 Realman Chassis Control (TCP)
+- 🎯 [GroundingDINO](https://github.com/IDEA-Research/GroundingDINO) for grounding-based visual detection
+- 📷 Intel RealSense Camera
+- 🧠 FastMCP protocol server
+
+---
+
+## 📦 Prerequisites
+
+- Python 3.10+
+- RealSense D435i (or compatible)
+- PyTorch 2.6.0
+- Redis server
+- Realman robot (arm + chassis)
+- GroundingDINO (see below)
+
+---
+
+## ⚙️ Installation
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/FlagOpen/RoboSkill
+
+cd RoboSkill/realman/RMC-LA
+
+```
+
+### 2. Install dependencies
+
+We recommend using a fresh virtual environment (e.g. with conda or venv):
+
+```bash
+pip install -r requirements.txt
+```
+
+### 3. Install GroundingDINO
+```bash
+git clone https://github.com/IDEA-Research/GroundingDINO.git
+
+cd GroundingDINO
+
+pip install -e .
+
+```
+Download the weights:
+```bash
+mkdir weights
+wget https://huggingface.co/IDEA-Research/GroundingDINO/resolve/main/groundingdino_swint_ogc.pth -P weights/
+```
+
+## 🔧 Configuration
+Before running, you must configure IP and port settings in `skill.py`:
+
+```bash
+# chassis
+chassis_host = "127.0.0.1"   # 🔁 Set to actual robot chassis IP
+chassis_port = 5000
+
+# arm
+arm_host = "127.0.0.1"       # 🔁 Set to actual robotic arm IP
+arm_port = 5000
+
+```
+
+## 🚀 Running the Service
+```bash
+python skill.py
+```
+This will:
+
++ Start the MCP-compatible skill server on http://0.0.0.0:8000
+
++ Load the GroundingDINO model
+
++ Initialize the RealSense camera
+
++ Initialize the Realman robotic arm
+
+
+
+## 📂 Output
+
++ `./output/wrist_obs.png`: Captured color image
+
++ `./output/annotated_image.png`: Visualized prediction with bounding boxes
+
++ `./output/wrist_obs_depth.npy`: Depth image
+
+
+
+## 🛠️ Troubleshooting
+
++ ❌ No RealSense Device Found
+Make sure the camera is plugged in and pyrealsense2 is installed.
+
++ ❌ Grasping Fails
+Ensure good lighting and that the target object is in the field of view.
+
++ ❌ Cannot connect to robot
+Double-check the IP/port values in skill.py.
+
+
+## 📄 License
+
+
+
+## ✨ Acknowledgments
++ [GroundingDINO](https://github.com/IDEA-Research/GroundingDINO)
++ [Intel RealSense SDK](https://github.com/IntelRealSense/librealsense)

--- a/realman/RMC-LA/requirements.txt
+++ b/realman/RMC-LA/requirements.txt
@@ -3,9 +3,9 @@ numpy==1.23.5
 scipy==1.9.3
 torch==2.6.0
 torchaudio==2.6.0
-torchvision==0.22.1
+torchvision==0.21.0
 Robotic-Arm==1.0.6
-pyrealsense2==2.54.1.5684
+pyrealsense2==2.55.1.6486
 opencv-python==4.6.0.66
 
 --e git+https://github.com/IDEA-Research/GroundingDINO.git@856dde20aee659246248e20734ef9ba5214f5e44#egg=groundingdino

--- a/realman/RMC-LA/skill.py
+++ b/realman/RMC-LA/skill.py
@@ -339,7 +339,7 @@ class RealmanArm:
 
 
 # Initialize FastMCP server
-mcp = FastMCP("robots")
+mcp = FastMCP("robots", stateless_http=True,  host='0.0.0.0', port=8888)
 
 
 @mcp.tool()
@@ -409,4 +409,4 @@ def grasp_object(object: str):
 
 if __name__ == "__main__":
     # Initialize and run the server
-    mcp.run(transport="stdio")
+    mcp.run(transport="streamable-http")

--- a/realman/RMC-LA/skill.py
+++ b/realman/RMC-LA/skill.py
@@ -15,11 +15,11 @@ from Robotic_Arm.rm_robot_interface import RoboticArm, rm_thread_mode_e
 
 # chassis
 chassis_host = "127.0.0.1"
-chassis_port = "5000"
+chassis_port = 5000
 
 # arm
 arm_host = "127.0.0.1"
-arm_port = "5000"
+arm_port = 5000
 speed = 20
 radius = 0
 connect = 0
@@ -339,7 +339,7 @@ class RealmanArm:
 
 
 # Initialize FastMCP server
-mcp = FastMCP("robots", stateless_http=True,  host='0.0.0.0', port=8888)
+mcp = FastMCP("robots", stateless_http=True, host="0.0.0.0", port=8000)
 
 
 @mcp.tool()
@@ -370,6 +370,11 @@ def navigate_to_target(marker_name: str) -> dict:
     )
 
 
+dino = Dino()
+camera = Camera()
+arm = RealmanArm(arm_host, arm_port, speed, radius, connect, block)
+
+
 @mcp.tool()
 def grasp_object(object: str):
     """
@@ -382,14 +387,11 @@ def grasp_object(object: str):
         str: A message indicating whether the grasping operation succeeded or failed.
     """
 
-    dino = Dino()
-    camera = Camera()
-    arm = RealmanArm(arm_host, arm_port, speed, radius, connect, block)
-
     arm.observe()
     color_path, depth_path = camera.record_wrist_frame()
     boxes, _ = dino.predict(color_path, object)
-    if not boxes:
+
+    if boxes is None or boxes.numel() == 0:
         return f"{object} not found."
 
     uv = [int(x) for x in boxes[0][:2].numpy()]
@@ -397,10 +399,10 @@ def grasp_object(object: str):
     extrinsics = dino.transform_camera2base(gripper_pose)
     xyz = dino.uv_to_xyz(uv, depth_path, extrinsics)
 
-    grasp_pose = xyz.tolist() + [0, 0, 3.1]
-    grasp_pose[0] -= 0.04
-    grasp_pose[1] += 0.06
-    grasp_pose[2] -= 0.1
+    grasp_pose = xyz.tolist() + [1.57, -1.5707, 1.5]
+    grasp_pose[0] -= 0.09
+    grasp_pose[1] += 0.01
+    grasp_pose[2] -= 0.05
 
     success = arm.grasp(grasp_pose)
     camera.shutdown()


### PR DESCRIPTION
- Updated `FastMCP` initialization to support stateless HTTP mode with host `0.0.0.0` and port `8888`.
- Changed transport method from `stdio` to `streamable-http` for easier remote access and integration.